### PR TITLE
Accept non-string keys and values for parameters

### DIFF
--- a/aliyun/connection.py
+++ b/aliyun/connection.py
@@ -133,8 +133,11 @@ class Connection(object):
         try:
             s = unicode(request, encoding)
         except TypeError:
-            # Most likely request was already unicode
-            s = request
+            if not isinstance(request, unicode):
+                # We accept int etc. types as well
+                s = unicode(request)
+            else:
+                s = request
 
         res = urllib.quote(
             s.encode('utf8'),
@@ -240,7 +243,8 @@ class Connection(object):
         """Make a get request to the API.
 
         Args:
-            params (dict): The parameters to the request.
+            params (dict): The parameters to the request. Keys and values
+                           should be string types.
             paginated (bool): Should the results be paginated.
             encoding (str): Encoding of the parameters. By default reads
                             stdin encoding, or failing that default encoding,

--- a/tests/unit/aliyun/connection_test.py
+++ b/tests/unit/aliyun/connection_test.py
@@ -89,6 +89,10 @@ class CredentialsTest(unittest.TestCase):
         self.assertEqual(str, type(encoded))
         self.assertEqual('~%257E', encoded)
 
+        encoded = c._percent_encode(42)
+        self.assertEqual(str, type(encoded))
+        self.assertEqual('42', encoded)
+
     def testSignature(self):
         c = aliyun.connection.Connection('some_region_id',
                                          'ecs',


### PR DESCRIPTION
But recommend in the docs to use strings, because they are faster to handle
and we might want to be more strict in the future.