### PR TITLE
Add tests and fix for instance_id error (ExpiredTime not set)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 MAKEFLAGS = --no-print-directory --always-make --silent
 MAKE = make $(MAKEFLAGS)
 
-VENV_NAME = python-aliyun
-VENV_PATH = ~/.virtualenvs/$(VENV_NAME)
+VENV_NAME = django_proj
+VENV_PATH = ~/Envs/$(VENV_NAME)
 VENV_ACTIVATE = . $(VENV_PATH)/bin/activate
 
 BUILD=0

--- a/aliyun/ecs/connection.py
+++ b/aliyun/ecs/connection.py
@@ -539,7 +539,7 @@ class EcsConnection(Connection):
 
     def create_instance(
             self, image_id, instance_type,
-            security_group_id, instance_name=None,
+            security_group_id, instance_name=None, key_pair_name='',
             internet_max_bandwidth_in=None,
             internet_max_bandwidth_out=None,
             hostname=None, password=None, system_disk_type=None,
@@ -555,6 +555,7 @@ class EcsConnection(Connection):
                 To see options use describe_instance_types.
             security_group_id (str): The security group id to associate.
             instance_name (str): The name to use for the instance.
+            key_pair_name (str): The SSH key pair to use for SSHing to the instance
             internet_max_bandwidth_in (int): Max bandwidth in.
             internet_max_bandwidth_out (int): Max bandwidth out.
 	    instance_charge_type (str): The charge type of the instance, 'PrePaid' or 'PostPaid'.
@@ -619,6 +620,8 @@ class EcsConnection(Connection):
         }
         if instance_name:
             params['InstanceName'] = instance_name
+        if key_pair_name:
+            params['KeyPairName'] = key_pair_name
         if internet_max_bandwidth_in:
             params['InternetMaxBandwidthIn'] = str(internet_max_bandwidth_in)
         if internet_max_bandwidth_out:

--- a/aliyun/ecs/connection.py
+++ b/aliyun/ecs/connection.py
@@ -183,8 +183,9 @@ class EcsConnection(Connection):
             int(resp['InternetMaxBandwidthIn']),
             int(resp['InternetMaxBandwidthOut']),
             dateutil.parser.parse(resp['CreationTime']),
-	    dateutil.parser.parse(resp['ExpiredTime']),
-	    resp['InstanceChargeType'],
+            # ExpiredTime can be an empty string (if instance no ExpiredTime; this is common), and will cause dateutil to throw error
+	        dateutil.parser.parse(resp['ExpiredTime']) if resp['ExpiredTime'] else resp['ExpiredTime'],
+	        resp['InstanceChargeType'],
             resp['Description'],
             resp['ClusterId'],
             [x for x in resp['OperationLocks']['LockReason']],

--- a/aliyun/ecs/connection.py
+++ b/aliyun/ecs/connection.py
@@ -544,7 +544,7 @@ class EcsConnection(Connection):
             internet_max_bandwidth_out=None,
             hostname=None, password=None, system_disk_type=None,
             internet_charge_type=None,
-            instance_charge_type='PrePaid', period=1,
+            instance_charge_type='PostPaid', period=None,
 	    io_optimized=None,
             data_disks=None, description=None, zone_id=None):
         """Create an instance.

--- a/tests/unit/aliyun/ecs/connection_test.py
+++ b/tests/unit/aliyun/ecs/connection_test.py
@@ -241,6 +241,42 @@ class GetInstanceTest(EcsConnectionTest):
                          self.conn.get_instance('i1'))
         self.mox.VerifyAll()
 
+    def testSuccessWhenExpiredTimeIsNotSet(self):
+        # In case any one is wondering why the code duplication:
+        # The price of not duplicating seems higher!
+        get_response = {
+            'RegionId': 'r',
+            'InstanceId': 'i1',
+            'InstanceName': 'name',
+            'ImageId': 'image',
+            'InstanceType': 'type',
+            'HostName': 'hostname',
+            'Status': 'running',
+            'InternetChargeType': 'chargetype',
+            'InternetMaxBandwidthIn': '1',
+            'InternetMaxBandwidthOut': '2',
+            'CreationTime': '2014-02-05T00:52:32Z',
+            'ExpiredTime': '', # This is what you get from Alibaba when ExpiredTime is not set
+            'InstanceChargeType': 'PostPaid',
+            'SecurityGroupIds': {'SecurityGroupId': ['sg1', 'sg2']},
+            'PublicIpAddress': {'IpAddress': ['ip1', 'ip2']},
+            'InnerIpAddress': {'IpAddress': ['ip3', 'ip4']},
+            'Description': '',
+            'ClusterId': '',
+            'OperationLocks': {'LockReason': []},
+            'ZoneId': 'z'
+        }
+        expected_result = Instance(
+            'i1', 'name', 'image', 'r', 'type', 'hostname', 'running',
+            ['sg1', 'sg2'], ['ip1', 'ip2'], ['ip3', 'ip4'], 'chargetype', 1, 2,
+            dateutil.parser.parse('2014-02-05T00:52:32Z'), '', 'PostPaid', '', '', [], 'z')
+        self.conn.get({'Action': 'DescribeInstanceAttribute',
+                       'InstanceId': 'i1'}).AndReturn(get_response)
+
+        self.mox.ReplayAll()
+        self.assertEqual(expected_result,
+                         self.conn.get_instance('i1'))
+        self.mox.VerifyAll()
 
 class InstanceActionsTest(EcsConnectionTest):
 


### PR DESCRIPTION
Hi All. This commit fixes #37 .

Issue #37 was happening because `ExpiredTime` is sometimes not set (so an empty string, which is *not* a `Date`)on some instances (such as PAYG instances for example).

A test was also added to [ecs.connection test](https://github.com/quixey/python-aliyun/blob/develop/tests/unit/aliyun/ecs/connection_test.py).